### PR TITLE
feat: make quality品質チェック厳格化 - 問題発見時に確実に失敗

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ go-lint:
 			echo "❌ golangci-lint で問題が検出されました"; \
 			echo "🔍 詳細確認のため go vet も実行します..."; \
 			go vet ./...; \
+			exit 1; \
 		fi; \
 	elif [ -f "$$(go env GOPATH)/bin/golangci-lint" ]; then \
 		if $$(go env GOPATH)/bin/golangci-lint run ./...; then \
@@ -246,6 +247,7 @@ go-lint:
 			echo "❌ golangci-lint で問題が検出されました"; \
 			echo "🔍 詳細確認のため go vet も実行します..."; \
 			go vet ./...; \
+			exit 1; \
 		fi; \
 	else \
 		echo "⚠️  golangci-lint がインストールされていません - go vetで代用"; \
@@ -300,13 +302,17 @@ go-security:
 		if gosec ./...; then \
 			echo "✅ gosec セキュリティスキャン完了 - 問題なし"; \
 		else \
-			echo "⚠️  gosec で潜在的なセキュリティ問題が検出されました"; \
+			echo "❌ gosec で重要なセキュリティ問題が検出されました"; \
+			echo "🔍 修正が必要です"; \
+			exit 1; \
 		fi; \
 	elif [ -f "$$(go env GOPATH)/bin/gosec" ]; then \
 		if $$(go env GOPATH)/bin/gosec ./...; then \
 			echo "✅ gosec セキュリティスキャン完了 - 問題なし"; \
 		else \
-			echo "⚠️  gosec で潜在的なセキュリティ問題が検出されました"; \
+			echo "❌ gosec で重要なセキュリティ問題が検出されました"; \
+			echo "🔍 修正が必要です"; \
+			exit 1; \
 		fi; \
 	else \
 		echo "⚠️  gosecがインストールされていません - go vetで基本チェックを実行"; \

--- a/internal/kvstore/kvstore.go
+++ b/internal/kvstore/kvstore.go
@@ -53,7 +53,12 @@ func (kv *KVStore) Put(key, value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log close error but don't override main error
+			fmt.Printf("Warning: failed to close file: %v\n", closeErr)
+		}
+	}()
 
 	// Use TAB-delimited format for legacy compatibility
 	logEntry := fmt.Sprintf("%s\t%s\n", key, value)
@@ -108,7 +113,12 @@ func (kv *KVStore) Delete(key string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log close error but don't override main error
+			fmt.Printf("Warning: failed to close file: %v\n", closeErr)
+		}
+	}()
 
 	// Use TAB-delimited format with __DELETED__ marker for legacy compatibility
 	logEntry := fmt.Sprintf("%s\t__DELETED__\n", key)
@@ -156,7 +166,12 @@ func (kv *KVStore) Compact() error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log close error but don't override main error
+			fmt.Printf("Warning: failed to close temp file: %v\n", closeErr)
+		}
+	}()
 
 	keys := make([]string, 0, len(data))
 	for key := range data {

--- a/internal/kvstore/reader.go
+++ b/internal/kvstore/reader.go
@@ -36,7 +36,12 @@ func (lr *LogReader) ReadAll() (map[string]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log close error but don't override main error
+			fmt.Printf("Warning: failed to close file: %v\n", closeErr)
+		}
+	}()
 
 	return lr.parseLogFile(file)
 }
@@ -51,7 +56,12 @@ func (lr *LogReader) ReadAllEntries() ([]LogEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log close error but don't override main error
+			fmt.Printf("Warning: failed to close file: %v\n", closeErr)
+		}
+	}()
 
 	var entries []LogEntry
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
- golangci-lintで問題検出時にexit 1を追加
- gosecでセキュリティ問題検出時にexit 1を追加
- テストファイル除外により製品コード問題のみに集中
- CI/CDと開発での品質保証を厳格化

これで品質問題がある状態でのビルド・デプロイを防止

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

# 🔄 Pull Request

## 📋 Summary
<!-- このPRの内容を簡潔に説明してください -->

## 🎯 Type
<!-- 該当するものにチェックを入れてください -->
- [ ] ✨ **feat**: 新機能
- [ ] 🐛 **fix**: バグ修正  
- [ ] 📝 **docs**: ドキュメント更新
- [ ] 🎨 **style**: コードスタイル修正（機能変更なし）
- [ ] ♻️ **refactor**: リファクタリング
- [ ] ✅ **test**: テスト追加・修正
- [ ] 🔧 **chore**: ビルド・補助ツール・ライブラリ更新
- [ ] 🚀 **ci**: CI/CD設定変更

## 🔗 Related Issues
<!-- 関連するIssueがあれば記載してください -->
Closes #<!-- Issue番号 -->

## 📊 Changes
<!-- 変更内容の詳細を記載してください -->
### Added (追加)
- 

### Changed (変更)
- 

### Fixed (修正)
- 

### Removed (削除)
- 

## 🧪 Test Plan
<!-- テスト方法を記載してください -->
### Manual Testing (手動テスト)
- [ ] 基本機能の動作確認
- [ ] エラーケースの確認
- [ ] 既存機能への影響確認

### Automated Testing (自動テスト)
- [ ] `make quality` が成功する
- [ ] `make test` が成功する  
- [ ] CI/CDパイプラインが成功する

### Performance Testing (性能テスト)
<!-- 性能に影響がある場合のみ記載 -->
- [ ] 性能測定を実行し、劣化がないことを確認
- [ ] ベンチマーク結果を比較

## 🔍 Code Review Checklist
### General (一般)
- [ ] コードが読みやすく、適切にコメントされている
- [ ] CLAUDE.mdの開発ガイドラインに従っている
- [ ] 適切なエラーハンドリングが実装されている
- [ ] セキュリティの考慮がなされている

### Shell Scripts (シェルスクリプト)
<!-- シェルスクリプトを変更した場合のみチェック -->
- [ ] shellcheckでリンティングが通る
- [ ] 適切な権限設定がされている
- [ ] エラーハンドリングが実装されている
- [ ] 引数バリデーションが適切

### Documentation (ドキュメント)
- [ ] 必要に応じてREADMEを更新
- [ ] 新機能の使用方法を記載
- [ ] コメントが適切に記載されている

### Compatibility (互換性)
- [ ] 既存のmoz.logファイル形式との互換性を保持
- [ ] レガシーコードとの共存を考慮
- [ ] 既存のMakefileターゲットに影響なし

## 📱 Screenshots / Demo
<!-- UI変更や新機能のデモがあれば追加してください -->

## 📚 Additional Notes
<!-- その他の注意点や補足情報があれば記載してください -->

## ✅ Final Checklist
### Pre-submission (提出前)
- [ ] 自分でコードレビューを実施
- [ ] ローカルで全てのテストが成功
- [ ] コミットメッセージがConventional Commits形式
- [ ] ブランチ名がCLAUDE.mdの命名規則に準拠

### Ready for Review (レビュー準備完了)
- [ ] このPRは完成しており、レビュー可能な状態
- [ ] 全ての関連Issueが適切にリンクされている
- [ ] 必要なドキュメント更新が完了している

---

<!-- 
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
-->