### PR TITLE
fix: add dependabot branch naming support for automated dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
           branch_name="${{ github.head_ref }}"
           echo "チェック対象ブランチ: $branch_name"
           
-          if ! echo "$branch_name" | grep -E "^(feat|fix|hotfix|test|docs|ci|cicd|refactor|perf|security|deps)/.*"; then
+          if ! echo "$branch_name" | grep -E "^(feat|fix|hotfix|test|docs|ci|cicd|refactor|perf|security|deps|dependabot)/.*"; then
             echo "❌ ブランチ名がCLAUDE.mdの命名規則に従っていません"
             echo "📋 推奨形式:"
             echo "   feat/issue-X-feature-name"
@@ -261,6 +261,7 @@ jobs:
             echo "   docs/X-description"
             echo "   test/X-description"
             echo "   refactor/X-description"
+            echo "   dependabot/* (automated dependency updates)"
             exit 1
           fi
           

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Use descriptive, consistent branch names:
 - Performance: `perf/X-description`
 - Security: `security/X-description`
 - Dependencies: `deps/X-description`
+- Automated dependency updates: `dependabot/*` (handled by Dependabot)
 
 ### Commit Message Format
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ git-hooks:
 	@echo 'fi' >> .git/hooks/pre-commit
 	@echo '' >> .git/hooks/pre-commit
 	@echo '# Check branch naming convention' >> .git/hooks/pre-commit
-	@echo 'if ! echo "$$current_branch" | grep -E "^(feat|fix|hotfix|test|docs|ci|cicd|refactor|perf|security|deps)/.*" > /dev/null; then' >> .git/hooks/pre-commit
+	@echo 'if ! echo "$$current_branch" | grep -E "^(feat|fix|hotfix|test|docs|ci|cicd|refactor|perf|security|deps|dependabot)/.*" > /dev/null; then' >> .git/hooks/pre-commit
 	@echo '    echo "⚠️  ブランチ名がCLAUDE.mdの命名規則に従っていません"' >> .git/hooks/pre-commit
 	@echo '    echo "📋 推奨形式:"' >> .git/hooks/pre-commit
 	@echo '    echo "   feat/issue-X-feature-name"' >> .git/hooks/pre-commit


### PR DESCRIPTION
## Summary
- ✅ Fix CI branch protection failures for Dependabot PRs
- ✅ Add `dependabot/*` pattern to branch naming validation
- ✅ Update all branch naming enforcement points for consistency

## Problem
Dependabot PRs were failing CI due to branch naming violations. Dependabot creates branches like `dependabot/github_actions/package-name` which didn't match our naming pattern.

## Changes
- **CI workflow**: Added `dependabot` to branch protection regex pattern
- **Makefile git-hooks**: Updated pre-commit hooks to include dependabot pattern  
- **CLAUDE.md**: Documented Dependabot branch naming exception

## Test plan
- [x] Quality checks pass
- [x] Branch naming pattern now includes dependabot/*
- [x] Fixes will resolve CI failures on PRs #35 and #36

This should allow Dependabot PRs to pass CI branch protection checks.

🤖 Generated with [Claude Code](https://claude.ai/code)