### PR TITLE
fix: 性能比較スクリプトの構文エラー修正

### DIFF
--- a/scripts/performance_comparison.sh
+++ b/scripts/performance_comparison.sh
@@ -172,14 +172,16 @@ EOF
         "duration": "$(echo "$shell_result" | cut -d'|' -f3)"
       },
       "speedup_factor": "$speedup"
-    }EOF
+    }
+EOF
         done
         
-        cat >> "${report_file}.json" << EOF
+        cat >> "${report_file}.json" << 'EOF'
 
   }
 }
 EOF
+    fi
     
     # Generate Markdown report
     if [ "$REPORT_FORMAT" = "markdown" ] || [ "$REPORT_FORMAT" = "both" ]; then


### PR DESCRIPTION
## Summary
- scripts/performance_comparison.shの構文エラーを修正
- make bench-compareコマンドの動作を復旧

## 問題の詳細

### 発生していた問題
scripts/performance_comparison.sh: line 276: syntax error near unexpected token '}'
make: *** [bench-compare] Error 2

### 根本原因
- heredoc構文の不正な形式（}EOF）
- heredocでの変数展開制御不備

## 修正内容

### 🔧 Heredoc構文の正規化
修正前: }EOF
修正後: }\nEOF

### 🔧 変数展開制御の追加
修正前: cat >> file << EOF
修正後: cat >> file << 'EOF'

## Test plan
- [x] bash構文チェック通過確認
- [x] make bench-compare実行可能確認
- [x] 性能ベンチマーク動作検証
- [x] 品質チェック通過確認

## 検証結果
bash構文チェック: エラー無し
make bench-quick: 正常実行確認

## 影響範囲
- make bench-compareコマンド
- make bench-quickコマンド
- 性能測定・比較機能全般

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>